### PR TITLE
Move the annotation to an api package

### DIFF
--- a/src/main/java/org/jboss/arquillian/testcontainers/TestContainerProvider.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/TestContainerProvider.java
@@ -11,9 +11,10 @@ import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.annotation.ClassScoped;
+import org.jboss.arquillian.testcontainers.api.TestContainerInstances;
 import org.testcontainers.containers.GenericContainer;
 
-public class TestContainerProvider extends OperatesOnDeploymentAwareProvider {
+class TestContainerProvider extends OperatesOnDeploymentAwareProvider {
     @Inject
     @ClassScoped
     private Instance<TestContainerInstances> containerInstances;
@@ -26,7 +27,7 @@ public class TestContainerProvider extends OperatesOnDeploymentAwareProvider {
             if (instances.all().size() == 1) {
                 return instances.get(0);
             }
-            // if there is more then 1 container, search if there is a matching qualifier
+            // if there is more than 1 container, search if there is a matching qualifier
             for (GenericContainer<?> container : instances.all()) {
                 for (Annotation qualifier : qualifiers) {
                     if (container.getClass().isAnnotationPresent(qualifier.annotationType())) {
@@ -35,7 +36,7 @@ public class TestContainerProvider extends OperatesOnDeploymentAwareProvider {
                 }
             }
         }
-        // if there are more than 1 containers and no qualifier matches, return all instances
+        // if there are more than 1 container and no qualifier matches, return all instances
         return instances;
     }
 

--- a/src/main/java/org/jboss/arquillian/testcontainers/TestContainersExtension.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/TestContainersExtension.java
@@ -7,7 +7,7 @@ package org.jboss.arquillian.testcontainers;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-public class TestContainersExtension implements LoadableExtension {
+class TestContainersExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         builder

--- a/src/main/java/org/jboss/arquillian/testcontainers/TestContainersObserver.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/TestContainersObserver.java
@@ -18,11 +18,13 @@ import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.arquillian.test.spi.annotation.ClassScoped;
 import org.jboss.arquillian.test.spi.event.suite.AfterClass;
 import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+import org.jboss.arquillian.testcontainers.api.TestContainer;
+import org.jboss.arquillian.testcontainers.api.TestContainerInstances;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
 @SuppressWarnings("unused")
-public class TestContainersObserver {
+class TestContainersObserver {
     @Inject
     @ClassScoped
     private InstanceProducer<TestContainerInstances> containersWrapper;
@@ -33,8 +35,7 @@ public class TestContainersObserver {
         TestClass javaClass = beforeClass.getTestClass();
         TestContainer tcAnno = javaClass.getAnnotation(TestContainer.class);
         if (tcAnno != null) {
-            boolean isDockerAvailable = isDockerAvailable();
-            checkForDocker(tcAnno.failIfNoDocker(), isDockerAvailable);
+            checkForDocker(tcAnno.failIfNoDocker(), isDockerAvailable());
             List<GenericContainer<?>> containers = new ArrayList<>();
             for (Class<? extends GenericContainer<?>> clazz : tcAnno.value()) {
                 try {

--- a/src/main/java/org/jboss/arquillian/testcontainers/api/TestContainer.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/api/TestContainer.java
@@ -2,7 +2,7 @@
  * Copyright The Arquillian Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.jboss.arquillian.testcontainers;
+package org.jboss.arquillian.testcontainers.api;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/org/jboss/arquillian/testcontainers/api/TestContainerInstances.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/api/TestContainerInstances.java
@@ -2,7 +2,7 @@
  * Copyright The Arquillian Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.jboss.arquillian.testcontainers;
+package org.jboss.arquillian.testcontainers.api;
 
 import java.lang.annotation.Annotation;
 import java.util.Iterator;
@@ -12,9 +12,9 @@ import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.testcontainers.containers.GenericContainer;
 
 public class TestContainerInstances implements Iterable<GenericContainer<?>> {
-    private List<GenericContainer<?>> containers;
+    private final List<GenericContainer<?>> containers;
 
-    TestContainerInstances(List<GenericContainer<?>> containers) {
+    public TestContainerInstances(List<GenericContainer<?>> containers) {
         this.containers = containers;
     }
 
@@ -49,7 +49,7 @@ public class TestContainerInstances implements Iterable<GenericContainer<?>> {
         return null;
     }
 
-    void beforeStart(ContainerRegistry registry) {
+    public void beforeStart(ContainerRegistry registry) {
         for (GenericContainer<?> container : all()) {
             if (container instanceof TestContainerLifecycle) {
                 ((TestContainerLifecycle) container).beforeStart(this, registry);
@@ -57,7 +57,7 @@ public class TestContainerInstances implements Iterable<GenericContainer<?>> {
         }
     }
 
-    void afterStart(ContainerRegistry registry) {
+    public void afterStart(ContainerRegistry registry) {
         for (GenericContainer<?> container : all()) {
             if (container instanceof TestContainerLifecycle) {
                 ((TestContainerLifecycle) container).afterStart(this, registry);
@@ -65,7 +65,7 @@ public class TestContainerInstances implements Iterable<GenericContainer<?>> {
         }
     }
 
-    void beforeStop(ContainerRegistry registry) {
+    public void beforeStop(ContainerRegistry registry) {
         for (GenericContainer<?> container : all()) {
             if (container instanceof TestContainerLifecycle) {
                 ((TestContainerLifecycle) container).beforeStop(this, registry);

--- a/src/main/java/org/jboss/arquillian/testcontainers/api/TestContainerLifecycle.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/api/TestContainerLifecycle.java
@@ -2,7 +2,7 @@
  * Copyright The Arquillian Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.jboss.arquillian.testcontainers;
+package org.jboss.arquillian.testcontainers.api;
 
 import org.jboss.arquillian.container.spi.ContainerRegistry;
 

--- a/src/test/java/org/jboss/arquillian/testcontainers/SanityTest.java
+++ b/src/test/java/org/jboss/arquillian/testcontainers/SanityTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testcontainers.api.TestContainer;
 import org.jboss.arquillian.testcontainers.test.common.SimpleTestContainer;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;


### PR DESCRIPTION
Move annotation and related public-facing classes to new package Modify scope on non-public classes to help limit exposure