### PR TITLE
Change annotation name

### DIFF
--- a/src/main/java/org/jboss/arquillian/testcontainers/ContainerInjectionTestEnricher.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/ContainerInjectionTestEnricher.java
@@ -17,8 +17,8 @@ import java.util.stream.Stream;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.spi.TestEnricher;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -33,7 +33,7 @@ public class ContainerInjectionTestEnricher implements TestEnricher {
 
     @Override
     public void enrich(final Object testCase) {
-        if (!isAnnotatedWith(testCase.getClass(), DockerRequired.class)) {
+        if (!isAnnotatedWith(testCase.getClass(), TestcontainersRequired.class)) {
             return;
         }
         for (Field field : getFieldsWithAnnotation(testCase.getClass())) {

--- a/src/main/java/org/jboss/arquillian/testcontainers/TestContainersObserver.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/TestContainersObserver.java
@@ -17,7 +17,7 @@ import org.jboss.arquillian.test.spi.annotation.ClassScoped;
 import org.jboss.arquillian.test.spi.event.enrichment.AfterEnrichment;
 import org.jboss.arquillian.test.spi.event.suite.AfterClass;
 import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.testcontainers.DockerClientFactory;
 
 @SuppressWarnings("unused")
@@ -30,7 +30,7 @@ class TestContainersObserver {
     private Instance<ContainerRegistry> registry;
 
     /**
-     * This first checks if the {@link DockerRequired} annotation is present on the test class failing if necessary. It
+     * This first checks if the {@link TestcontainersRequired} annotation is present on the test class failing if necessary. It
      * then creates the {@link TestcontainerRegistry} and stores it in a {@link ClassScoped} instance.
      *
      * @param beforeClass the before class event
@@ -39,7 +39,7 @@ class TestContainersObserver {
      */
     public void createContainer(@Observes(precedence = 500) BeforeClass beforeClass) throws Throwable {
         final TestClass javaClass = beforeClass.getTestClass();
-        final DockerRequired dockerRequired = javaClass.getAnnotation(DockerRequired.class);
+        final TestcontainersRequired dockerRequired = javaClass.getAnnotation(TestcontainersRequired.class);
         if (dockerRequired != null) {
             if (!isDockerAvailable()) {
                 var throwable = dockerRequired.value();

--- a/src/main/java/org/jboss/arquillian/testcontainers/api/Testcontainer.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/api/Testcontainer.java
@@ -16,13 +16,12 @@ import org.testcontainers.containers.GenericContainer;
 
 /**
  * Used to annotate a field which <strong>must</strong> be an instance of a {@link GenericContainer}. A
- * {@link DockerRequired} annotation must be present on the type to use Testcontainer injection.
+ * {@link TestcontainersRequired} annotation must be present on the type to use Testcontainer injection.
  *
  * <pre>
- * &#064;ExtendWith(ArquillianExtension.class)
+ * &#064;RunWith(Arquillian.class)
+ * &#064;TestcontainersRequired
  * &#064;RunAsClient
- * // By throwing the TestAbortedException, the test will be skipped if docker is not available
- * &#064;DockerRequired(TestAbortedException.class)
  * public class ContainerTest {
  *
  *     &#064;Testcontainer

--- a/src/main/java/org/jboss/arquillian/testcontainers/api/TestcontainersRequired.java
+++ b/src/main/java/org/jboss/arquillian/testcontainers/api/TestcontainersRequired.java
@@ -12,7 +12,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * An annotation which will check if docker is available and if not throw an exception. By default, this will throw an
+ * An annotation which will check if container engine is available and if not throw an exception. By default, this will throw an
  * {@link AssertionError}. However, you can define the type of exception to throw. The exception <strong>must</strong>
  * have a string or no-arg constructor.
  *
@@ -24,16 +24,16 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })
-public @interface DockerRequired {
+public @interface TestcontainersRequired {
 
     /**
      * The type of the exception to throw. The exception must have a public string constructor.
      * <p>
-     * By default this throws an {@link AssertionError} error. However, this could throw, for example, a
+     * By default, this throws an {@link AssertionError}. However, this could throw, for example, a
      * {@code TestAbortedException} to act as an Assumption error.
      * </p>
      *
-     * @return the exception type to throw if docker is not available
+     * @return the exception type to throw if container engine is not available
      */
     Class<? extends Throwable> value() default AssertionError.class;
 }

--- a/src/test/java/org/jboss/arquillian/testcontainers/test/ManualContainerTest.java
+++ b/src/test/java/org/jboss/arquillian/testcontainers/test/ManualContainerTest.java
@@ -8,8 +8,8 @@ package org.jboss.arquillian.testcontainers.test;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.testcontainers.test.common.SimpleTestContainer;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -27,7 +27,7 @@ import org.opentest4j.TestAbortedException;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @ExtendWith(ArquillianExtension.class)
-@DockerRequired(TestAbortedException.class)
+@TestcontainersRequired(TestAbortedException.class)
 @RunAsClient
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ManualContainerTest {

--- a/src/test/java/org/jboss/arquillian/testcontainers/test/MultipleContainerTest.java
+++ b/src/test/java/org/jboss/arquillian/testcontainers/test/MultipleContainerTest.java
@@ -8,8 +8,8 @@ package org.jboss.arquillian.testcontainers.test;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.testcontainers.test.common.SimpleTestContainer;
 import org.jboss.arquillian.testcontainers.test.common.WildFlyContainer;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -24,7 +24,7 @@ import org.opentest4j.TestAbortedException;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @ExtendWith(ArquillianExtension.class)
-@DockerRequired(TestAbortedException.class)
+@TestcontainersRequired(TestAbortedException.class)
 @RunAsClient
 public class MultipleContainerTest {
 

--- a/src/test/java/org/jboss/arquillian/testcontainers/test/SameInstanceTest.java
+++ b/src/test/java/org/jboss/arquillian/testcontainers/test/SameInstanceTest.java
@@ -8,8 +8,8 @@ package org.jboss.arquillian.testcontainers.test;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.testcontainers.test.common.SimpleTestContainer;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -29,7 +29,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@DockerRequired(TestAbortedException.class)
+@TestcontainersRequired(TestAbortedException.class)
 public class SameInstanceTest {
 
     @Testcontainer

--- a/src/test/java/org/jboss/arquillian/testcontainers/test/SanityTest.java
+++ b/src/test/java/org/jboss/arquillian/testcontainers/test/SanityTest.java
@@ -8,8 +8,8 @@ package org.jboss.arquillian.testcontainers.test;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.testcontainers.test.common.SimpleTestContainer;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -24,7 +24,7 @@ import org.opentest4j.TestAbortedException;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@DockerRequired(TestAbortedException.class)
+@TestcontainersRequired(TestAbortedException.class)
 public class SanityTest {
 
     @Testcontainer

--- a/src/test/java/org/jboss/arquillian/testcontainers/test/TypeSpecifiedInjectionTest.java
+++ b/src/test/java/org/jboss/arquillian/testcontainers/test/TypeSpecifiedInjectionTest.java
@@ -8,8 +8,8 @@ package org.jboss.arquillian.testcontainers.test;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.arquillian.testcontainers.api.Testcontainer;
+import org.jboss.arquillian.testcontainers.api.TestcontainersRequired;
 import org.jboss.arquillian.testcontainers.test.common.SimpleTestContainer;
 import org.jboss.arquillian.testcontainers.test.common.WildFlyContainer;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -26,7 +26,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 @ExtendWith(ArquillianExtension.class)
 @RunAsClient
-@DockerRequired(TestAbortedException.class)
+@TestcontainersRequired(TestAbortedException.class)
 public class TypeSpecifiedInjectionTest {
 
     @Deployment


### PR DESCRIPTION
Rename DockerRequired to ContainerRequired
Clean up stray references to "docker"

Resolves #39.